### PR TITLE
Fix nanotime_now precision for Switch implementation

### DIFF
--- a/nanotime.h
+++ b/nanotime.h
@@ -498,7 +498,7 @@ void nanotime_sleep(uint64_t nsec_count) {
 #ifdef __SWITCH__
 #include <switch.h>
 uint64_t nanotime_now() {
-	return svcGetSystemTick();
+	return armTicksToNs(armGetSystemTick());
 }
 #define NANOTIME_NOW_IMPLEMENTED
 #endif


### PR DESCRIPTION
On Switch, `nanotime_now()` currently uses `svcGetSystemTicks()` which returns ticks in milliseconds. This change uses the correct system calls to get ticks in nanoseconds.